### PR TITLE
Add a subcommand for preparing training data for gp mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env/
+env3/
 .cache/
 .pytest_cache/
 *__pycache__*

--- a/gramophone/scripts/gramophone.py
+++ b/gramophone/scripts/gramophone.py
@@ -7,11 +7,14 @@ import string
 import click
 from itertools import groupby
 from bz2file import BZ2File
+from tqdm import tqdm
 
 import wiktionary_de_parser as wdp
 
 from gramophone import gp
 from gramophone import hy
+
+clean_wiki_re = re.compile('[ˈˌ\\-,]')
 
 @click.group()
 def cli():
@@ -40,12 +43,25 @@ def prechew_gp(dump):
     #
     # iterate over records
     #
-    for record in wdp.Parser(bz):
+    training_data = {}
+    for record in tqdm(wdp.Parser(bz), total=820000):
         # read only German entries
         if 'language' not in record or record['language'] != 'Deutsch':
             continue
+        # skipping multi word expressions!
         elif 'syllables' in record and 'ipa' in record and not any(c in record['title'] for c in string.whitespace):
-            click.echo("%s\t%s" % ("".join(record['syllables']),record.get('ipa')))
+            graph_rep = "".join(record['syllables']).lower()
+            phon_rep = clean_wiki_re.sub("", record.get('ipa'))
+            if graph_rep not in training_data:
+                training_data[graph_rep] = set()
+            training_data[graph_rep].add(phon_rep)
+
+    #
+    # print training data
+    #
+    for graph_rep, phon_reps in training_data.items():
+        for phon_rep in phon_reps:
+            click.echo("%s\t%s" % (graph_rep, phon_rep))
 
 @GP.command(name="train")
 @click.option('-M', '--mapping', required=True, help='grapheme-phoneme mapping')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Flask
 pytest
 wiktionary_de_parser
 bz2file
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ click
 Flask
 -e git://github.com/adsva/python-wapiti.git#egg=libwapiti
 pytest
+wiktionary_de_parser
+bz2file


### PR DESCRIPTION
Given a `de.wiktionary` dump, a word-to-IPA mapping which may be
used for generating a gramophone model is printed to stdout. The
hard work is done by
https://github.com/gambolputty/wiktionary_de_parser.