### PR TITLE
Add output and filter option to gp mode

### DIFF
--- a/gramophone/gp/alignment.py
+++ b/gramophone/gp/alignment.py
@@ -76,13 +76,16 @@ class Aligner:
         alignment_fst = self.__align_fst(g,p)
         if alignment_fst.start() == -1:
             return []
-        return(self.__extract_alignments(self.__align_fst(g,p)))
+        return self.__extract_alignments(alignment_fst)
 
-    def scan(self,g):
+    def scan(self,g, grapheme=True):
         '''
-        Tokenizes a grapheme sequence.
+        Tokenizes a grapheme or a phoneme sequence.
         '''
-        return(self.__extract_segmentations(self.segment(g)))
+        if grapheme:
+            return(self.__extract_segmentations(self.segment(g)))
+        else:
+            return(self.__extract_segmentations(self.expand(g)))
 
 
     def __align_fst(self,g,p):


### PR DESCRIPTION
Different output modi for transcription are now available. An
option for a fixed replacement on IPA side has been added as well:
It is now possible to replace undesired IPA symbols (e.g. the
incorrect affricate-consonant representation with two symbols and
a connecting arc frequently used in the German wiktionary).

Fixes #12